### PR TITLE
Temporary fix for nonce issues caused by Flask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN pip install -r /tmp/requirements.txt
 COPY ./app /app
 ADD gunicorn_config.py /gunicorn_config.py
 EXPOSE 5000
-ENTRYPOINT ["gunicorn", "--config", "/gunicorn_config.py", "wsgi:app"]
+ENTRYPOINT ["python3", "app.py"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This [document](https://docs.blackboard.com/standards/lti/tutorials/py-lti-1p3) 
 ## ConfigTemplate.py
 
 Copy `ConfigTemplate.py` to `Config.py` and fill in your information:
+
 ```
 config = {
     "verify_certs" : "True",
@@ -20,12 +21,16 @@ config = {
     "app_url" : "YOURAPPURLWITHHTTPS"
 }
 ```
-* **learn_rest_url** should be set to your learn instances domain. Be sure to avoid the request scheme, i.e. `mylearn.blackboard.edu`
-* **app_url** should be set to the FQDN of your application, i.e. `https://myapp.herokuapp.com`
+
+- **learn_rest_url** should be set to your learn instances domain. Be sure to avoid the request scheme, i.e. `mylearn.blackboard.edu`
+- **app_url** should be set to the FQDN of your application, i.e. `https://myapp.herokuapp.com`
+
 ## lti-template.json
-Copy `lti-template.json` to `lti.json` and fill in your information. 
+
+Copy `lti-template.json` to `lti.json` and fill in your information.
 Example - Replace the fffa0f... values with your client_id, and the deployment id value with the deployment id you get when
 you deploy your tool on a learn system. This tool is currently built so that it only works with exactly one Learn instance:
+
 ```
 {
     "https://blackboard.com": {
@@ -42,6 +47,7 @@ you deploy your tool on a learn system. This tool is currently built so that it 
 ```
 
 In the app directory you also need to generate your tool's private.key and public.key files that are in the app directory:
+
 ```
 openssl genrsa -out private.key 2048
 openssl rsa -in private.key -pubout -out public.key
@@ -49,7 +55,7 @@ openssl rsa -in private.key -pubout -out public.key
 
 ## To Run
 
-First run `pip install -r requirements.txt`  and then `python app.py` or if you are using heroku, just check in the code to your dyno.
+First run `pip install -r requirements.txt` and then `python app.py` or if you are using heroku, just check in the code to your dyno.
 
 OR
 Use the included Dockerfile and the following. The assumption is that you have Docker desktop an ngrok on your development system.
@@ -63,10 +69,16 @@ $ docker run -p 5000:5000 --rm --name LaunchExternal launch-external:0.1
 
 NOTE: When you host this LTI application on a remote server the app MUST have it's own unique subdomain. I.E. you must use something like https://launchexternal.myschool.edu/ or https://launchexternal.apps.myschool.edu/ as the root path to the tool. Per the LTI specification you can NOT use https://myschoolapps.myschool.edu/launchexternal/ where launchexternal is one of the many apps you have under the root.
 
+If you wish to have an intermediate (interstitial page) showing a warning to your users I.E: "Be careful, you're leaving Blackboard Learn", you need to comment the line "return(redirect(external_url))" in the app/app.py file and uncommet the line "eturn render_template('external.html', launch_url=external_url)"."
+
+Then, you can modify the external.html file (located in app/templates) with the custom warning you want to show to your users, or, create a link in the page instead of opening the external page as a popup (some users could miss the popup notification.)
+
 ## On your Learn server
+
 Register the LTI 1.3 tool with your client_id.
 Create a "Course content tool" managed placment for the URL you want to launch to with a custom parameter external_url= to where you want to launch.
 Example:
+
 ```
     Label: Foodies With User Name
     Handle: foodieswithusername
@@ -75,10 +87,11 @@ Example:
     Custom Parameters: external_url=https://www.foodies.com?user%3D@X@user.id@X@
 ```
 
-Note that the url will be escaped by Learn to be:external_url=https://www.foodies.com?user=@X@user.id@X@
+Note that the url will be escaped by Learn to be: external_url=https://www.foodies.com?user=@X@user.id@X@
 You need to input the = sign after user as %3D, because Learn will not accept an = there as it thinks that is another custom parameter. I.E. You input external_url=https://www.foodies.com?user%3D@X@user.id@X@ and when you hit submit Learn parses that, replacing the %3D with the = sign.
+
+If the information of the user (or any additional paramenter) is not required, you can remove it from the parameter and leave external_url=https://www.foodies.com/ as the value in the placement.
 
 You can do the same to create custom launches from system tool or administration tool links.
 You can use any of the @X@ template variables described here in your launch:
 https://docs.blackboard.com/learn/b2/advanced/dynamic-rendering-with-template-variables
-

--- a/README.md
+++ b/README.md
@@ -69,14 +69,16 @@ $ docker run -p 5000:5000 --rm --name LaunchExternal launch-external:0.1
 
 NOTE: When you host this LTI application on a remote server the app MUST have it's own unique subdomain. I.E. you must use something like https://launchexternal.myschool.edu/ or https://launchexternal.apps.myschool.edu/ as the root path to the tool. Per the LTI specification you can NOT use https://myschoolapps.myschool.edu/launchexternal/ where launchexternal is one of the many apps you have under the root.
 
-If you wish to have an intermediate (interstitial page) showing a warning to your users I.E: "Be careful, you're leaving Blackboard Learn", you need to comment the line "return(redirect(external_url))" in the app/app.py file and uncommet the line "eturn render_template('external.html', launch_url=external_url)"."
+By default, the tool will show an intermediate (interstitial page) when launching the external link, this is to warn the users that they're going out of Blackboard Learn, however, if you want to disable this setting and redirect the users to the external page in the same browser tab, you need to add to the parameters of the placement the following line:
 
-Then, you can modify the external.html file (located in app/templates) with the custom warning you want to show to your users, or, create a link in the page instead of opening the external page as a popup (some users could miss the popup notification.)
+disable_intertitial=True
+
+You can modify the external.html file (located in app/templates) with the custom warning you want to show to your users, or, create a link in the page instead of opening the external page as a popup (some users could miss the popup notification.)
 
 ## On your Learn server
 
 Register the LTI 1.3 tool with your client_id.
-Create a "Course content tool" managed placment for the URL you want to launch to with a custom parameter external_url= to where you want to launch.
+Create a "Course content tool" managed placement for the URL you want to launch to with a custom parameter external_url= to where you want to launch.
 Example:
 
 ```
@@ -90,7 +92,7 @@ Example:
 Note that the url will be escaped by Learn to be: external_url=https://www.foodies.com?user=@X@user.id@X@
 You need to input the = sign after user as %3D, because Learn will not accept an = there as it thinks that is another custom parameter. I.E. You input external_url=https://www.foodies.com?user%3D@X@user.id@X@ and when you hit submit Learn parses that, replacing the %3D with the = sign.
 
-If the information of the user (or any additional paramenter) is not required, you can remove it from the parameter and leave external_url=https://www.foodies.com/ as the value in the placement.
+If the information of the user (or any additional parameter) is not required, you can remove it from the parameter list and leave external_url=https://www.foodies.com/ as the value in the placement.
 
 You can do the same to create custom launches from system tool or administration tool links.
 You can use any of the @X@ template variables described here in your launch:

--- a/app/app.py
+++ b/app/app.py
@@ -186,7 +186,7 @@ def launch():
     using the state parameter. The state is an opaque value that doesn't get modified by the 
     developer portal or by Learn. We take the external URL that will be launched to and include it as
     a portion of the state to be pulled out on the other side of 3LO. It's the only way across. 
-    Attempts to pass the data by adding an additional parameter to the requestß for a authroization code
+    Attempts to pass the data by adding an additional parameter to the request for a authroization code
     will fail because those will be dropped. I.E setting your redirect_uri to .../authcode/?launch_url=URL
     does not work.
     https://stackabuse.com/encoding-and-decoding-base64-strings-in-python/
@@ -217,7 +217,7 @@ def launch():
     By default, the tool will show an interstitial page with additional information (such as "Be careful, you're leaving Blackboard")
     If you want to remove this page and redirect directly to the external page, you need to add an additional parameter to the placement with the following information
     disable_interstitial=True
-    You can modify the file external.html in the templates folder with the information you need keeping in mind that you need 
+    You can modify the file external.html in the templates folder with the information you need to show to the users as warning, keeping in mind that you need 
     to leave the window.open line within the script tags or create a link the users can click to avoid issues with popup blockers
     """
 

--- a/app/app.py
+++ b/app/app.py
@@ -167,22 +167,97 @@ def launch():
     launch_data_storage = get_launch_data_storage()
     message_launch = ExtendedFlaskMessageLaunch(flask_request, tool_conf, launch_data_storage=launch_data_storage)
     message_launch_data = message_launch.get_launch_data()
-    pprint.pprint(message_launch_data)
+    #pprint.pprint(message_launch_data)
 
+    tpl_kwargs = {
+        'page_title': PAGE_TITLE,
+        'is_deep_link_launch': message_launch.is_deep_link_launch(),
+        'launch_data': message_launch.get_launch_data(),
+        'launch_id': message_launch.get_launch_id(),
+        'curr_user_name': message_launch_data.get('name', '')
+    }
+    
+    """ 
+    We are now going to not do the following. We are going to launch to the external page here. 
+    NO 3LO!!
+    We could do the launch to the external page here. The following which does the 3LO with REST APIs
+    back to the Learn system is not necessary. It's an artifact of project this one was leveraged from.
+    We left it here for the most part to demonstrate how one can pass data through the 3LO process
+    using the state parameter. The state is an opaque value that doesn't get modified by the 
+    developer portal or by Learn. We take the external URL that will be launched to and include it as
+    a portion of the state to be pulled out on the other side of 3LO. It's the only way across. 
+    Attempts to pass the data by adding an additional parameter to the requestß for a authroization code
+    will fail because those will be dropped. I.E setting your redirect_uri to .../authcode/?launch_url=URL
+    does not work.
+    https://stackabuse.com/encoding-and-decoding-base64-strings-in-python/
+    """
+
+    disable_interstitial = False
+    learn_url = message_launch_data['https://purl.imsglobal.org/spec/lti/claim/tool_platform']['url'].rstrip('/')
+    
     #MUST include a custom parameter like 'external_url=https://www.foodies.com' in the custom params
     #Since no authentication is being done, you can choose to leave the user=@X@user.id@X@ param in the custom parameters of the tool.
     external_url = message_launch_data['https://purl.imsglobal.org/spec/lti/claim/custom']['external_url'].rstrip('/')
-    print("Redirecting to: " + external_url)
-    return(redirect(external_url))
+    if "disable_interstitial" in message_launch_data['https://purl.imsglobal.org/spec/lti/claim/custom']:
+        disable_interstitial = message_launch_data['https://purl.imsglobal.org/spec/lti/claim/custom']['disable_interstitial'].rstrip('/')
+    state = str(uuid.uuid4()) + f'&launch_url={external_url}'
+    message_bytes = state.encode('ascii')
+    base64_bytes = base64.b64encode(message_bytes)
+    base64_message = base64_bytes.decode('ascii')
+
+    params = {
+        'redirect_uri' : Config.config['app_url'] + '/authcode/',
+        'response_type' : 'code',
+        'client_id' : Config.config['learn_rest_key'],
+        'scope' : '*',
+        'state' : base64_message
+    }
 
     """
-    If you want to show an interstitial page with additional information (such as "Be careful, you're leaving Blackboard")
-    You need to comment the line above "return(redirect(external_url))"and uncomment the line below.
+    By default, the tool will show an interstitial page with additional information (such as "Be careful, you're leaving Blackboard")
+    If you want to remove this page and redirect directly to the external page, you need to add an additional parameter to the placement with the following information
+    disable_interstitial=True
     You can modify the file external.html in the templates folder with the information you need keeping in mind that you need 
     to leave the window.open line within the script tags or create a link the users can click to avoid issues with popup blockers
     """
 
-    #return render_template('external.html', launch_url=external_url)
+    if disable_interstitial == "True":
+        return(redirect(external_url))
+    
+    encodedParams = urllib.parse.urlencode(params)
+
+    get_authcode_url = learn_url + '/learn/api/public/v1/oauth2/authorizationcode?' + encodedParams
+
+    #Used for 3LO authentication
+    #print("NOT USING: authcode_URL: " + get_authcode_url, flush=True)
+    #return(redirect(get_authcode_url))
+    
+    return render_template('external.html', launch_url=external_url)
+
+@app.route('/authcode/', methods=['GET', 'POST'])
+def authcode():
+    # we are going to stop coming here to avoid any issues that may be caused by 3LO.
+    authcode = request.args.get('code', '')
+    base64_message = request.args.get('state', '')
+    base64_bytes = base64_message.encode('ascii')
+    message_bytes = base64.b64decode(base64_bytes)
+    state = message_bytes.decode('ascii')
+    launch_url = state.split("&launch_url=",1)[1]
+
+    print ("authcode: " + authcode, flush=True)
+    print ("base64_message: " + base64_message, flush=True)
+    print ("state: " + state, flush=True)
+    print ("launch_url: " + launch_url, flush=True)
+    
+    
+    restAuthController = RestAuthController.RestAuthController(authcode)
+    restAuthController.setToken()
+    token = restAuthController.getToken()
+    uuid = restAuthController.getUuid()
+
+    login_user(User(uuid))
+
+    return render_template('external.html', launch_url=launch_url)
 
 if __name__ == '__main__':
     restAuthController = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Flask-DebugToolbar==0.11.0
 PyLTI1p3==1.7.0
 flask-login==0.5.0
 gunicorn==20.0.4
+Werkzeug==1.0.1


### PR DESCRIPTION
- Modified requirements.txt adding a missing requirement. 
- Completely removed authentication since it is not needed for external launches. 
- Modified Dockerfile to change the entry point and avoid Flask entirely (Docker Container issues caused by it), the tool still runs in a container
- Modified the launch route to allow a direct redirect to the external page or allow admins to show an interstitial page to warn their users
- Modified README.md file adding the information about the interstitial page and information about the parameters.